### PR TITLE
nivida egl vendor config file add , enhance the performance of render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,5 +115,8 @@ EOF
 
 RUN chmod +x /usr/local/bin/check-versions 
 
+RUN mkdir -p /usr/share/glvnd/egl_vendor.d/ && \
+   echo '{\n    "file_format_version" : "1.0.0",\n    "ICD" : {\n        "library_path" : "libEGL_nvidia.so.0"\n    }\n}' > /usr/share/glvnd/egl_vendor.d/10_nvidia.json
+
 # Add health check
 HEALTHCHECK CMD python3 -c "import discoverse, torch, numpy, cv2, mujoco; print('All dependencies installed successfully')" 


### PR DESCRIPTION
解决了 libEGL加载错误的问题

这个问题主要是由egl的vendor的目录里没有nvidia的json文件导致的。

加了这个配置之后，3dgs场景下的捡箱子有速度的提升

https://github.com/user-attachments/assets/d2fca82e-e0cd-41c5-ba2a-e9c8dfa10fae

#13 